### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,3 @@ jobs:
         - ./vendor/bin/phpunit -v --coverage-clover ./build/logs/clover.xml
       after_script:
         - php ./vendor/bin/coveralls -v
-
-  allow_failures:
-    - php: 7.4snapshot


### PR DESCRIPTION
removed PHP-7.4 from `.travis.yml` allow_failures to make it compatible with PHP 7.4.
See #1023